### PR TITLE
feat(website): add auto/light/dark theme switcher

### DIFF
--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -4,11 +4,65 @@ const base = import.meta.env.BASE_URL;
 <header class="site-header">
   <div class="container">
     <a href={base} class="brand">arabterm</a>
-    <nav>
-      <a href={base}>الرئيسية</a>
-      <a href={`${base}about/`}>عن المشروع</a>
-      <a href="https://wikitermbase.toolforge.org/" target="_blank" rel="noopener">مسرد الويكي</a>
-      <a href="https://github.com/forzagreen/arabterm" target="_blank" rel="noopener">GitHub</a>
-    </nav>
+    <div class="header-right">
+      <nav>
+        <a href={base}>الرئيسية</a>
+        <a href={`${base}about/`}>عن المشروع</a>
+        <a href="https://wikitermbase.toolforge.org/" target="_blank" rel="noopener">مسرد الويكي</a>
+        <a href="https://github.com/forzagreen/arabterm" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <div class="theme-switch" role="group" aria-label="نمط العرض">
+        <button type="button" data-theme-value="auto" aria-pressed="false" title="تلقائي" aria-label="تلقائي">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="2" y="4" width="20" height="14" rx="2" />
+            <path d="M8 21h8M12 18v3" />
+          </svg>
+        </button>
+        <button type="button" data-theme-value="light" aria-pressed="false" title="فاتح" aria-label="فاتح">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+          </svg>
+        </button>
+        <button type="button" data-theme-value="dark" aria-pressed="false" title="داكن" aria-label="داكن">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+          </svg>
+        </button>
+      </div>
+    </div>
   </div>
 </header>
+
+<script is:inline>
+  (function () {
+    var root = document.documentElement;
+    var media = window.matchMedia('(prefers-color-scheme: dark)');
+    var buttons = document.querySelectorAll('.theme-switch button[data-theme-value]');
+
+    function apply(pref) {
+      var resolved = pref === 'dark' || (pref === 'auto' && media.matches) ? 'dark' : 'light';
+      root.dataset.themePref = pref;
+      root.dataset.theme = resolved;
+      buttons.forEach(function (b) {
+        b.setAttribute('aria-pressed', b.dataset.themeValue === pref ? 'true' : 'false');
+      });
+    }
+
+    var stored;
+    try { stored = localStorage.getItem('theme'); } catch (e) {}
+    apply(stored || 'auto');
+
+    buttons.forEach(function (b) {
+      b.addEventListener('click', function () {
+        var pref = b.dataset.themeValue;
+        try { localStorage.setItem('theme', pref); } catch (e) {}
+        apply(pref);
+      });
+    });
+
+    media.addEventListener('change', function () {
+      if ((root.dataset.themePref || 'auto') === 'auto') apply('auto');
+    });
+  })();
+</script>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -16,7 +16,22 @@ const meta = description ?? 'قاعدة بيانات للقواميس العرب
 <html lang="ar" dir="rtl">
   <head>
     <meta charset="utf-8" />
+    <!-- Apply the saved theme before first paint to avoid a flash of the wrong theme. -->
+    <script is:inline>
+      (function () {
+        try {
+          var pref = localStorage.getItem('theme') || 'auto';
+          var sysDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var resolved = pref === 'dark' || (pref === 'auto' && sysDark) ? 'dark' : 'light';
+          var root = document.documentElement;
+          root.dataset.themePref = pref;
+          root.dataset.theme = resolved;
+        } catch (e) {}
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0f1115" media="(prefers-color-scheme: dark)" />
     <title>{fullTitle}</title>
     <meta name="description" content={meta} />
     <link rel="icon" type="image/x-icon" href={`${import.meta.env.BASE_URL}favicon.ico`} />

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -5,10 +5,25 @@
   --border: #e5e7eb;
   --accent: #0f766e;
   --accent-hover: #115e59;
+  --on-accent: #ffffff;
   --surface: #f9fafb;
   --row-alt: #f8fafc;
   --max-width: 1100px;
+  color-scheme: light;
   font-family: 'Noto Naskh Arabic', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+:root[data-theme='dark'] {
+  --bg: #0f1115;
+  --fg: #e6e8eb;
+  --muted: #9aa3af;
+  --border: #2a2f3a;
+  --accent: #2dd4bf;
+  --accent-hover: #5eead4;
+  --on-accent: #0b0e13;
+  --surface: #171a21;
+  --row-alt: #161922;
+  color-scheme: dark;
 }
 
 * {
@@ -73,6 +88,48 @@ header.site-header nav a {
 header.site-header nav a:hover {
   color: var(--accent);
   text-decoration: none;
+}
+header.site-header .header-right {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.theme-switch {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg);
+}
+.theme-switch button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 1.9rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  line-height: 0;
+}
+.theme-switch button + button {
+  border-inline-start: 1px solid var(--border);
+}
+.theme-switch button:hover {
+  color: var(--fg);
+}
+.theme-switch button[aria-pressed='true'] {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+.theme-switch svg {
+  width: 1.05rem;
+  height: 1.05rem;
+  display: block;
 }
 
 footer.site-footer {
@@ -216,7 +273,7 @@ table.terms td.desc {
   display: inline-block;
   padding: 0.5rem 0.9rem;
   background: var(--accent);
-  color: #fff;
+  color: var(--on-accent);
   border-radius: 6px;
   font-weight: 500;
   font-size: 0.95rem;
@@ -251,7 +308,7 @@ nav.pagination span {
   border-radius: 4px;
   font-size: 0.9rem;
   color: var(--fg);
-  background: #fff;
+  background: var(--bg);
 }
 nav.pagination a:hover {
   border-color: var(--accent);
@@ -260,7 +317,7 @@ nav.pagination a:hover {
 }
 nav.pagination span.current {
   background: var(--accent);
-  color: #fff;
+  color: var(--on-accent);
   border-color: var(--accent);
   font-weight: 600;
 }


### PR DESCRIPTION
## Summary

Adds a three-way theme switcher (auto / light / dark) to the website header.

- **Auto** (default): follows the OS `prefers-color-scheme` and updates live when the OS theme changes.
- **Light / Dark**: forces that theme and persists across pages and visits via `localStorage`.

The saved preference is applied before first paint (inline script in `<head>`) to avoid a flash of the wrong theme.

## Changes

- **BaseLayout.astro** — inline no-flash script that sets `data-theme` from `localStorage` before paint; added `theme-color` metas for light/dark.
- **Header.astro** — segmented control with three icon buttons (تلقائي / فاتح / داكن) plus wiring script (active state, persistence, live OS-change handling).
- **global.css** — `:root[data-theme='dark']` palette, new `--on-accent` token for readable button text on the dark-mode accent, `color-scheme` per theme, `.theme-switch` styles. Also fixed two hardcoded `#fff` values (pagination cell backgrounds, button text on accent) that would have broken in dark mode.

## Testing

- `npm run build` passes — 494 pages built.
- Verified the switcher markup, no-flash script, and new CSS token are present in the build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)