### PR TITLE
fix: preserve NULL updated_at when migrating dictionaries to MariaDB

### DIFF
--- a/arabterm/scripts/migrate_to_mariadb.py
+++ b/arabterm/scripts/migrate_to_mariadb.py
@@ -2,6 +2,7 @@ import datetime
 import sys
 from typing import Any, Dict
 
+from sqlalchemy import null
 from sqlalchemy.orm import Session
 
 from arabterm.mariadb_models import Dictionary as DictionaryMariaDB
@@ -25,7 +26,11 @@ def migrate_dictionary(sqlite_dict: DictionarySQLite) -> Dict[str, Any]:
         "dict_type": sqlite_dict.dict_type,
         "tier": sqlite_dict.tier,
         "created_at": sqlite_dict.created_at or datetime.datetime.now(),
-        "updated_at": sqlite_dict.updated_at,
+        # A plain `None` here is indistinguishable to SQLAlchemy from "no value
+        # given" and gets silently dropped from the INSERT, letting MariaDB's
+        # `DEFAULT CURRENT_TIMESTAMP` stamp the row with now() on every re-run.
+        # `null()` forces an explicit SQL NULL to be written instead.
+        "updated_at": sqlite_dict.updated_at if sqlite_dict.updated_at is not None else null(),
     }
 
 


### PR DESCRIPTION
## Summary
- SQLAlchemy treats an explicit `None` the same as "no value given" for a column with a `server_default`, so it silently dropped `updated_at` from the `INSERT` when a SQLite dictionary had `updated_at IS NULL`
- Since `dictionary.updated_at` in MariaDB defaults to `CURRENT_TIMESTAMP`, those 24 dictionaries got stamped with `now()` on every `migrate_to_mariadb` run, producing a spurious `db/mariadb/arabterm.sql.gz` diff (and a bogus `notify-wikitermbase` trigger) on every dump regeneration even when no underlying data changed
- Now passes `sqlalchemy.null()` for those rows to force an explicit SQL `NULL` instead

## Test plan
- [x] Ran `make delete_mariadb && make migrate_to_mariadb` twice in a row against the local MariaDB container — the 24 previously-NULL dictionaries stayed `NULL` both times instead of drifting to a new timestamp
- [x] Ran `search_mariadb.py telescope` smoke test — FULLTEXT search still works
- [x] Ran `make dump` and diffed decompressed `db/mariadb/arabterm.sql.gz` against the prior committed dump — only those 24 rows' `updated_at` changed (timestamp → `NULL`), nothing else
- [x] Confirmed `db/sqlite/arabterm.sql.gz` content is byte-identical (left uncommitted)